### PR TITLE
Add repository field to readme

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,5 +23,9 @@
     }
   },
   "author": "ForbesLindesay",
-  "license": "MIT"
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ForbesLindesay/queue.git"
+  }
 }


### PR DESCRIPTION
I am a bot.  I add repository fields to package.json files because they're super useful for npm.
